### PR TITLE
Dynamics runtime errors fixes 

### DIFF
--- a/Scripts/Libs/crAsh/Dynamics.Script.txt
+++ b/Scripts/Libs/crAsh/Dynamics.Script.txt
@@ -15,22 +15,24 @@ Add the code in Match_StartMap:
 Add the code in Match_PlayLoop:
 	Dynamics::Compute();
 
-Add the code to coresponding events:
+Add the code in Match_EndMap:
+	Dynamics::Clear();
 
+Add the code to coresponding events:
 CSmModeEvent::EType::OnPlayerTouchesObject: {
-						declare Boolean PerformEliminate = Dynamics::CheckEliminatingObject(Event.Object, "touch", Event.Player);
-							
-						if(PerformEliminate) {
-							if(Player::getLastCheckpoint(Victim) == NullId && (ServerModeName == "" || ServerLogin == "")) {
-								Dynamics::ForceResetAll();
-							}
-							Obstacle::ObsRespawnPlayer(Event.Player);
-						}
-						
-						if(Dynamics::IsDynamic(Event.Object)) {
-								Events::Invalid(Event);
-								continue;
-						}
+	declare Boolean PerformEliminate = Dynamics::CheckEliminatingObject(Event.Object, "touch", Event.Player);
+		
+	if(PerformEliminate) {
+		if(Player::getLastCheckpoint(Victim) == NullId && (ServerModeName == "" || ServerLogin == "")) {
+			Dynamics::ForceResetAll();
+		}
+		Obstacle::ObsRespawnPlayer(Event.Player);
+	}
+	
+	if(Dynamics::IsDynamic(Event.Object)) {
+			Events::Invalid(Event);
+			continue;
+	}
 	
 CSmModeEvent::EType::OnHit CODE:
 	Dynamics::OnHit(Event.Victim, Event.VictimEntity);
@@ -44,7 +46,7 @@ Add also extra code in foreach (RS in PendingRespawns) Loop
   CONSTANTS
  *********************************************/
 
-#Const  Version     "2023-09-07"
+#Const  Version     "2024-03-12"
 #Const  ScriptName  "Dynamics.Script.txt"
 
 #Include "TextLib" as TL
@@ -119,6 +121,13 @@ Void RemoveFromDynamics() {
 			}
 			
 		}
+	}
+}
+
+//Clear objects from an array
+Void Clear() {
+	if(Dynamics.count > 0) {
+		Dynamics.clear();
 	}
 }
 

--- a/Scripts/Modes/ShootMania/Obstacle.Script.txt
+++ b/Scripts/Modes/ShootMania/Obstacle.Script.txt
@@ -729,7 +729,7 @@ G_LastUsePvPWeapons = UsePvPWeapons;
 ***
 EndTime = -1;
 
-Dynamics.Clear();
+Dynamics::Clear();
 Items::Destroy();
 UIManager.UIAll.MarkersXML = "";
 SM::UnspawnAllPlayers();

--- a/Scripts/Modes/ShootMania/Obstacle.Script.txt
+++ b/Scripts/Modes/ShootMania/Obstacle.Script.txt
@@ -729,6 +729,7 @@ G_LastUsePvPWeapons = UsePvPWeapons;
 ***
 EndTime = -1;
 
+Dynamics.Clear();
 Items::Destroy();
 UIManager.UIAll.MarkersXML = "";
 SM::UnspawnAllPlayers();


### PR DESCRIPTION
That's simple code that should provide fixes for following runtime errors caused by Dynamics lib: 

![ss+(2024-02-10+at+11 17 13)](https://github.com/Obstacle-Reborn/Titlepack/assets/23433857/4e23f9be-c736-4ee9-9c5b-e141dec3af6f)

![92791898df065578fc77ad211ac19f10](https://github.com/Obstacle-Reborn/Titlepack/assets/23433857/e5be81b8-7195-4d84-b259-1c49f627f2ed)
